### PR TITLE
net-voip/twinkle: drop unneeded dependency

### DIFF
--- a/net-voip/twinkle/twinkle-1.10.3-r1.ebuild
+++ b/net-voip/twinkle/twinkle-1.10.3-r1.ebuild
@@ -14,8 +14,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="alsa diamondcard g729 ilbc speex +qt5"
 
-DEPEND="dev-cpp/commoncpp2
-	dev-libs/boost
+DEPEND="dev-libs/boost
 	dev-libs/ucommon
 	dev-libs/libxml2
 	media-libs/fontconfig


### PR DESCRIPTION
Signed-off-by: Victor Kustov <ktrace@yandex.ru>